### PR TITLE
feature/fixScriptPaths

### DIFF
--- a/BuildScripts/run_sourcery.sh
+++ b/BuildScripts/run_sourcery.sh
@@ -7,8 +7,8 @@ import CoreLocation
 import Foundation
 import Shared
 "
-sourcery                                            \
-  --sources "$SRCROOT/Shared"                       \
-  --templates "$SRCROOT/Shared/Sourcery/Templates"  \
-  --args imports="$AUTO_MOCKABLE_IMPORTS"           \
-  --output "$SRCROOT/Shared/Sourcery/Output"
+sourcery                                                \
+  --sources "$PROJECT_DIR/Shared"                       \
+  --templates "$PROJECT_DIR/Shared/Sourcery/Templates"  \
+  --args imports="$AUTO_MOCKABLE_IMPORTS"               \
+  --output "$PROJECT_DIR/Shared/Sourcery/Output"


### PR DESCRIPTION
Updates script to use $PROJECT_DIR instead of SRCROOT, so that the correct path is found when Shared is built in a workspace